### PR TITLE
Spit-swallow-revert

### DIFF
--- a/scripts/source/OCumScript.psc
+++ b/scripts/source/OCumScript.psc
@@ -176,9 +176,10 @@ Event OstimOrgasm(string eventName, string strArg, float numArg, Form sender)
 			endif
 		ElseIf (cumAmount > 0 && ostim.IsOral())
 			SendModEvent("ocum_cumoral", numArg=cumAmount)
+		Else
+			CumShoot(orgasmer, cumamount)
 		endif
 
-		CumShoot(orgasmer, cumamount)
 		if (orgasmer == playerref)|| (partner == playerref)
 			ostim.SetOrgasmStall(false) 
 			TempDisplayBar()


### PR DESCRIPTION
I reverted the spit/swallow mechanic changes from OCumScript. I also moved the CumShoot call so that it doesn't do cum shots during vaginal or oral animations. Now cum shouldn't be shooting out of the back of people's heads.